### PR TITLE
Use tetromino index insted of concrete tetromino

### DIFF
--- a/src/components/PlayField.vue
+++ b/src/components/PlayField.vue
@@ -7,12 +7,12 @@
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from "vue-property-decorator"
 import BoardConfigs from "../@types/BoardConfigs"
-import Tetromino from "../@types/Tetromino"
+import { Tetrominos } from "../Tetrominos"
 
 @Component
 export default class PlayField extends Vue {
   @Prop() configs!: BoardConfigs
-  @Prop() tetromino!: Tetromino
+  @Prop() tetrominoIndex!: number
   @Prop() flipFlopTurn!: boolean
 
   isBlockFilled!: boolean[][]
@@ -156,8 +156,8 @@ export default class PlayField extends Vue {
   }
 
   drawTetromino(): void {
-    this.context.fillStyle = this.tetromino.color
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    this.context.fillStyle = Tetrominos[this.tetrominoIndex].color
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           this.context.fillRect(
@@ -178,7 +178,7 @@ export default class PlayField extends Vue {
   }
 
   clearTetromino(): void {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           this.context.clearRect(
@@ -199,18 +199,19 @@ export default class PlayField extends Vue {
   }
 
   fillBlocksAndColorByTetromino(): void {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           this.isBlockFilled[this.currentY + dy][this.currentX + dx] = true
-          this.colorBoard[this.currentY + dy][this.currentX + dx] = this.tetromino.color
+          this.colorBoard[this.currentY + dy][this.currentX + dx] =
+            Tetrominos[this.tetrominoIndex].color
         }
       }
     }
   }
 
   moveLeft(): void {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy][this.currentX + dx - 1]) return
@@ -223,7 +224,7 @@ export default class PlayField extends Vue {
     this.drawTetromino()
   }
   moveRight(): void {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy][this.currentX + dx + 1]) return
@@ -236,7 +237,7 @@ export default class PlayField extends Vue {
     this.drawTetromino()
   }
   moveDown(): boolean {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy + 1][this.currentX + dx]) {
@@ -259,9 +260,9 @@ export default class PlayField extends Vue {
     while (this.moveDown());
   }
   rotateLeft(): void {
-    const leftRotation: number = (this.rotation + 1) % this.tetromino.blocks.length
+    const leftRotation: number = (this.rotation + 1) % Tetrominos[this.tetrominoIndex].blocks.length
 
-    for (const [dy, row] of this.tetromino.blocks[leftRotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[leftRotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy][this.currentX + dx]) return
@@ -275,9 +276,10 @@ export default class PlayField extends Vue {
   }
   rotateRight(): void {
     const rightRotation: number =
-      (this.rotation + this.tetromino.blocks.length - 1) % this.tetromino.blocks.length
+      (this.rotation + Tetrominos[this.tetrominoIndex].blocks.length - 1) %
+      Tetrominos[this.tetrominoIndex].blocks.length
 
-    for (const [dy, row] of this.tetromino.blocks[rightRotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[rightRotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy][this.currentX + dx]) return
@@ -323,7 +325,7 @@ export default class PlayField extends Vue {
   }
 
   isGameOver(): boolean {
-    for (const [dy, row] of this.tetromino.blocks[this.rotation].entries()) {
+    for (const [dy, row] of Tetrominos[this.tetrominoIndex].blocks[this.rotation].entries()) {
       for (const [dx, blockElement] of row.entries()) {
         if (blockElement != 0) {
           if (this.isBlockFilled[this.currentY + dy][this.currentX + dx]) return true

--- a/src/components/Tetris.vue
+++ b/src/components/Tetris.vue
@@ -3,7 +3,7 @@
     <play-field
       class="inline-block"
       :configs="configs"
-      :tetromino="tetromino"
+      :tetromino-index="tetrominoIndex"
       :flip-flop-turn="flipFlopTurn"
       @tetromino-grounded="popNextTetromino"
     />
@@ -22,7 +22,6 @@ import { Vue, Component } from "vue-property-decorator"
 import PlayField from "./PlayField.vue"
 import NextPreview from "./NextPreview.vue"
 import BoardConfigs from "../@types/BoardConfigs"
-import Tetromino from "../@types/Tetromino"
 import { Tetrominos } from "../Tetrominos"
 
 @Component({
@@ -38,18 +37,14 @@ export default class TetrisComponent extends Vue {
     height: 20 + 2
   }
 
-  tetromino: Tetromino = {
-    name: "",
-    color: "",
-    blocks: [[[]]]
-  }
-
   flipFlopTurn: boolean = true
   flipFlopNextTetrominoIndicesSet: boolean = true
 
   nextTetrominoIndicesSet: number[] = this.shuffle(Array.from(Array(Tetrominos.length).keys()))
   nextNextTetrominoIndicesSet: number[] = this.shuffle(Array.from(Array(Tetrominos.length).keys()))
   tetrominoIndicesIterator: IterableIterator<number> = this.nextTetrominoIndicesSet.values()
+
+  tetrominoIndex: number = this.nextTetrominoIndicesSet[0]
 
   mounted(): void {
     this.popNextTetromino()
@@ -66,7 +61,7 @@ export default class TetrisComponent extends Vue {
       this.nextNextTetrominoIndicesSet = this.shuffle(this.nextNextTetrominoIndicesSet)
       this.flipFlopNextTetrominoIndicesSet = !this.flipFlopNextTetrominoIndicesSet
     }
-    this.tetromino = Tetrominos[result.value]
+    this.tetrominoIndex = result.value
 
     // If current tetromino and next tetromino are the same ones,
     // Vue.js cannot detect the "change" of the tetromino.


### PR DESCRIPTION
When implementing HOLD feature we have to deep-copy tetromino in the current design, which leads to some unfavorable codes. Copying entire tetromino also takes more cost than copying just one number.
So now I'll change the design to use tetromino index insted of concrete tetromino.