### PR TITLE
Put LevelScore component in Tetris component

### DIFF
--- a/src/components/LevelScore.vue
+++ b/src/components/LevelScore.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="level-score">
     <p>
       LEVEL <br />
       {{ level }}
@@ -31,5 +31,9 @@ export default class LevelScore extends Vue {
   p {
     margin: 10px 0 10px;
   }
+}
+
+.level-score {
+  margin: 40px 0px;
 }
 </style>

--- a/src/components/NextPreview.vue
+++ b/src/components/NextPreview.vue
@@ -4,22 +4,16 @@
     <div id="next-preview-canvas-container">
       <canvas id="next-preview-canvas" />
     </div>
-    <level-score class="level-score" />
   </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component, Watch } from "vue-property-decorator"
-import LevelScore from "components/LevelScore.vue"
 import Tetromino from "typings/Tetromino"
 import { Tetrominos } from "Tetrominos"
 import { tetrominoIndicesModule } from "store/modules/TetrominoIndices"
 
-@Component({
-  components: {
-    LevelScore
-  }
-})
+@Component
 export default class NextPreview extends Vue {
   canvas!: HTMLCanvasElement
   context!: CanvasRenderingContext2D

--- a/src/components/NextPreview.vue
+++ b/src/components/NextPreview.vue
@@ -104,8 +104,4 @@ export default class NextPreview extends Vue {
   height: 100%;
   width: 100%;
 }
-
-.level-score {
-  margin: 40px 0px;
-}
 </style>

--- a/src/components/Tetris.vue
+++ b/src/components/Tetris.vue
@@ -5,7 +5,7 @@
       <play-field class="inline-block" />
       <div class="inline-block">
         <next-preview />
-        <level-score class="level-score" />
+        <level-score />
       </div>
     </div>
     <div>

--- a/src/components/Tetris.vue
+++ b/src/components/Tetris.vue
@@ -3,7 +3,10 @@
     <div id="tetris-component">
       <hold class="inline-block" />
       <play-field class="inline-block" />
-      <next-preview class="inline-block" />
+      <div class="inline-block">
+        <next-preview />
+        <level-score class="level-score" />
+      </div>
     </div>
     <div>
       <mobile-controller />
@@ -16,6 +19,7 @@ import { Vue, Component } from "vue-property-decorator"
 import Hold from "components/Hold.vue"
 import PlayField from "components/PlayField.vue"
 import NextPreview from "components/NextPreview.vue"
+import LevelScore from "components/LevelScore.vue"
 import MobileController from "components/MobileController.vue"
 
 @Component({
@@ -23,6 +27,7 @@ import MobileController from "components/MobileController.vue"
     Hold,
     PlayField,
     NextPreview,
+    LevelScore,
     MobileController
   }
 })


### PR DESCRIPTION
LevelScore component is not a child of NextPreview component semantically, but it should be put in the top Tetris component.